### PR TITLE
Optimization pass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(treewidth_lib INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include/treewidth"
   ${Boost_INCLUDE_DIRS})
 target_compile_features(treewidth_lib INTERFACE cxx_std_17)
-target_compile_options(treewidth_lib INTERFACE -Wall -Wextra)
+target_compile_options(treewidth_lib INTERFACE -Wall -Wextra -Woverloaded-virtual)
 
 # Optional AddressSanitizer + UndefinedBehaviorSanitizer build (used in CI).
 option(TREEWIDTH_SANITIZE "Build with ASan/UBSan" OFF)

--- a/include/treewidth/Bag.h
+++ b/include/treewidth/Bag.h
@@ -2,6 +2,7 @@
 #define Bag_h
 
 #include <unordered_set>
+#include <boost/unordered/unordered_flat_set.hpp>
 #include <vector>
 #include <ostream>
 
@@ -13,7 +14,7 @@ private:
   unsigned long parent=0;
   std::vector<unsigned long> children;
 public:
-  Bag(unsigned long id, const std::unordered_set<unsigned long> &nodeset){
+  Bag(unsigned long id, const boost::unordered_flat_set<unsigned long> &nodeset){
     this->id = id;
     nodes.reserve(nodeset.size());
     for(unsigned long node:nodeset) nodes.push_back(node);

--- a/include/treewidth/CE.h
+++ b/include/treewidth/CE.h
@@ -30,7 +30,7 @@ public:
     //building the first permutation
     strategy.init_permutation(graph);
     unsigned long node = strategy.get_next();
-    std::unordered_set<unsigned long> neigh = graph.get_neighbours(node);
+    boost::unordered_flat_set<unsigned long> neigh = graph.get_neighbours(node);
     //getting the neighbour with least overlap
     unsigned long min_v = 0;
     unsigned long min_ovl = neigh.size();

--- a/include/treewidth/CE.h
+++ b/include/treewidth/CE.h
@@ -42,10 +42,10 @@ public:
         min_v = v;
         min_ovl = ovl;
       }
-      //contracting the edge
-      graph.contract_edge(min_v,node);
     }
-  
+    //contracting the edge
+    graph.contract_edge(min_v,node);
+
 }
 };
 

--- a/include/treewidth/Delta2D.h
+++ b/include/treewidth/Delta2D.h
@@ -29,7 +29,7 @@ public:
 	//Computes estimation
   virtual unsigned long estimate(unsigned long prevBound=0) override {
     unsigned long treewidth = prevBound;
-    for(auto node:graph.get_nodes()) treewidth=estimateForNode(node,treewidth);
+    for(auto node:graph->get_nodes()) treewidth=estimateForNode(node,treewidth);
     return treewidth;
   }
   
@@ -38,7 +38,7 @@ private:
                                 unsigned long prevBound){
 		//building the first permutation
     unsigned long treewidth = prevBound;
-		graph_temp = graph;
+		graph_temp = *graph;
 		//The loop below intentionally stops once only one node remains in the
 		//queue (empty_but1()), so the queue is never left empty after a call.
 		//Since `strategy` is shared across every call to estimateForNode

--- a/include/treewidth/Delta2D.h
+++ b/include/treewidth/Delta2D.h
@@ -49,7 +49,7 @@ private:
 		strategy.init_permutation(graph_temp);
 		while (!strategy.empty_but1()) {
 			unsigned long node = strategy.get_second_next();
-			std::unordered_set<unsigned long> neigh = graph_temp.get_neighbours(node);
+			const std::unordered_set<unsigned long>& neigh = graph_temp.get_neighbours(node);
 			treewidth = std::max(treewidth, neigh.size());
 			unsigned long node_temp = strategy.get_next_wo_delete();
 			if (node_temp != prevNode ) {

--- a/include/treewidth/Delta2D.h
+++ b/include/treewidth/Delta2D.h
@@ -39,6 +39,13 @@ private:
 		//building the first permutation
     unsigned long treewidth = prevBound;
 		graph_temp = graph;
+		//The loop below intentionally stops once only one node remains in the
+		//queue (empty_but1()), so the queue is never left empty after a call.
+		//Since `strategy` is shared across every call to estimateForNode
+		//(Delta2D::estimate() reuses it for each node in the graph), it must be
+		//cleared here or the leftover entry from the previous call would desync
+		//the queue from this call's freshly-copied graph_temp.
+		strategy.clear();
 		strategy.init_permutation(graph_temp);
 		while (!strategy.empty_but1()) {
 			unsigned long node = strategy.get_second_next();

--- a/include/treewidth/Delta2D.h
+++ b/include/treewidth/Delta2D.h
@@ -49,7 +49,7 @@ private:
 		strategy.init_permutation(graph_temp);
 		while (!strategy.empty_but1()) {
 			unsigned long node = strategy.get_second_next();
-			const std::unordered_set<unsigned long>& neigh = graph_temp.get_neighbours(node);
+			const boost::unordered_flat_set<unsigned long>& neigh = graph_temp.get_neighbours(node);
 			treewidth = std::max(treewidth, neigh.size());
 			unsigned long node_temp = strategy.get_next_wo_delete();
 			if (node_temp != prevNode ) {

--- a/include/treewidth/FillInPermutationStrategy.h
+++ b/include/treewidth/FillInPermutationStrategy.h
@@ -27,10 +27,10 @@ protected:
                                   bool = false){
     unsigned long fillin = 0;
     if(graph.has_neighbours(node)){
-      std::unordered_set<unsigned long> nodes = graph.get_neighbours(node);
+      const std::unordered_set<unsigned long>& nodes = graph.get_neighbours(node);
       for(auto src: nodes){
         if(graph.has_neighbours(src)){
-          std::unordered_set<unsigned long> neigh = graph.get_neighbours(src);
+          const std::unordered_set<unsigned long>& neigh = graph.get_neighbours(src);
           for(auto tgt: nodes)
             if((src<tgt)&&(neigh.find(tgt)==neigh.end())) fillin++;
         }

--- a/include/treewidth/FillInPermutationStrategy.h
+++ b/include/treewidth/FillInPermutationStrategy.h
@@ -11,8 +11,8 @@
 class FillInPermutationStrategy: public PermutationStrategy{
 public:
   //For fill in, we need to look also at neighbours of neighbours
-  void recompute(const std::unordered_set<unsigned long> &nodes, Graph& graph) override {
-    std::unordered_set<unsigned long> new_nodes;
+  void recompute(const boost::unordered_flat_set<unsigned long> &nodes, Graph& graph) override {
+    boost::unordered_flat_set<unsigned long> new_nodes;
     for(auto node:nodes){
       new_nodes.insert(node);
       if(graph.has_neighbours(node))
@@ -27,10 +27,10 @@ protected:
                                   bool = false){
     unsigned long fillin = 0;
     if(graph.has_neighbours(node)){
-      const std::unordered_set<unsigned long>& nodes = graph.get_neighbours(node);
+      const boost::unordered_flat_set<unsigned long>& nodes = graph.get_neighbours(node);
       for(auto src: nodes){
         if(graph.has_neighbours(src)){
-          const std::unordered_set<unsigned long>& neigh = graph.get_neighbours(src);
+          const boost::unordered_flat_set<unsigned long>& neigh = graph.get_neighbours(src);
           for(auto tgt: nodes)
             if((src<tgt)&&(neigh.find(tgt)==neigh.end())) fillin++;
         }

--- a/include/treewidth/Graph.h
+++ b/include/treewidth/Graph.h
@@ -106,8 +106,9 @@ public:
   
   const std::unordered_set<unsigned long> &get_neighbours(unsigned long node) const{
     assert(has_node(node));
-
-    return (adj_list.find(node))->second;
+    static const std::unordered_set<unsigned long> empty;
+    auto it = adj_list.find(node);
+    return it == adj_list.end() ? empty : it->second;
   }
   
   const std::unordered_set<unsigned long> &get_nodes() const{

--- a/include/treewidth/Graph.h
+++ b/include/treewidth/Graph.h
@@ -2,14 +2,16 @@
 #define Graph_h
 #include <stdlib.h>
 #include <unordered_map>
+#include <boost/unordered/unordered_flat_map.hpp>
 #include <unordered_set>
+#include <boost/unordered/unordered_flat_set.hpp>
 #include <cassert>
 
 //Class for the graph
 class Graph{
 private:
-  std::unordered_map<unsigned long, std::unordered_set<unsigned long>> adj_list;
-  std::unordered_set<unsigned long> node_set;
+  boost::unordered_flat_map<unsigned long, boost::unordered_flat_set<unsigned long>> adj_list;
+  boost::unordered_flat_set<unsigned long> node_set;
   unsigned long num_edges = 0;
 
   
@@ -30,7 +32,7 @@ public:
   }
   
   // Returns adjacency list
-  std::unordered_set<unsigned long> remove_node(unsigned long node){
+  boost::unordered_flat_set<unsigned long> remove_node(unsigned long node){
     node_set.erase(node);
     for(auto neighbour:adj_list[node]){
       adj_list[neighbour].erase(node);
@@ -62,7 +64,7 @@ public:
 		return count > k-1;
 }
  
-  void fill(const std::unordered_set<unsigned long>& nodes,\
+  void fill(const boost::unordered_flat_set<unsigned long>& nodes,\
             bool undirected=true){
     for(auto src: nodes)
       for(auto tgt: nodes)
@@ -78,7 +80,10 @@ public:
   }
   
   void contract_edge(unsigned long src, unsigned long tgt){
-    for(auto v:get_neighbours(tgt))
+    //copy tgt's neighbours before the loop: add_edge mutates adj_list and the
+    //flat map has no reference stability, so iterating the live set is unsafe
+    boost::unordered_flat_set<unsigned long> neigh_tgt = get_neighbours(tgt);
+    for(auto v:neigh_tgt)
       if((v!=src)&&!has_edge(src,v)) add_edge(src,v);
     remove_node(tgt);
   }
@@ -100,14 +105,14 @@ public:
     return retval;
   }
   
-  const std::unordered_set<unsigned long> &get_neighbours(unsigned long node) const{
+  const boost::unordered_flat_set<unsigned long> &get_neighbours(unsigned long node) const{
     assert(has_node(node));
-    static const std::unordered_set<unsigned long> empty;
+    static const boost::unordered_flat_set<unsigned long> empty;
     auto it = adj_list.find(node);
     return it == adj_list.end() ? empty : it->second;
   }
   
-  const std::unordered_set<unsigned long> &get_nodes() const{
+  const boost::unordered_flat_set<unsigned long> &get_nodes() const{
     return node_set;
   }
   

--- a/include/treewidth/Graph.h
+++ b/include/treewidth/Graph.h
@@ -43,27 +43,23 @@ public:
   }
 
   bool neighbour_improved(unsigned k,unsigned long n1, unsigned long n2){
-		bool retval = false;		
 		auto &neigh1 = get_neighbours(n1);
 		auto &neigh2 = get_neighbours(n2);
-			
+
 		unsigned long count = 0;
 		if 	(neigh1.size()>k-1 && neigh2.size()>k-1){
-			for (auto nn1:neigh1){
-				for (auto nn2:neigh2){
-					if (nn1==nn2){
-						count = count+1;		
-						break;
-					}
-			
+			//count common neighbours by probing the larger set with the smaller,
+			//stopping as soon as the threshold is reached
+			const auto &small = neigh1.size()<neigh2.size()?neigh1:neigh2;
+			const auto &large = neigh1.size()<neigh2.size()?neigh2:neigh1;
+			for (auto nn:small){
+				if (large.find(nn)!=large.end()){
+					if (++count > k-1) break;
 				}
-			}		
-		}
-		if (count > k-1){
-			retval = true;
+			}
 		}
 
-		return retval;
+		return count > k-1;
 }
  
   void fill(const std::unordered_set<unsigned long>& nodes,\

--- a/include/treewidth/LBN.h
+++ b/include/treewidth/LBN.h
@@ -36,7 +36,11 @@ public:
       }
       //if the lower bound on the improved graph is greater
       //increase the lower bound estimation
-      lower_bound.setGraph(graph_temp);
+      //estimate on a disposable copy: the base bound is destructive, and
+      //graph_temp (the neighbour-improved graph) must survive to the next
+      //iteration (cf. LBNPlus, which likewise copies into graph_temp1)
+      Graph graph_temp_eval = graph_temp;
+      lower_bound.setGraph(graph_temp_eval);
       unsigned long lower_temp = lower_bound.estimate();
       //graph_temp = graph;
       if (lower_temp > lower){

--- a/include/treewidth/LBN.h
+++ b/include/treewidth/LBN.h
@@ -48,6 +48,9 @@ public:
         change = true;
       }
     }
+    //restore the base bound to the still-alive shared graph: it was last
+    //repointed at a loop-local copy that is about to go out of scope
+    lower_bound.setGraph(graph);
     return lower;
   }
 };

--- a/include/treewidth/LBNPlus.h
+++ b/include/treewidth/LBNPlus.h
@@ -55,6 +55,9 @@ public:
         change = true;
       }
     }
+    //restore the base bound to the still-alive shared graph: it was last
+    //repointed at a loop-local copy (graph_temp1) that is about to go out of scope
+    lower_bound.setGraph(graph);
     return lower;
   }
 };

--- a/include/treewidth/LowerBound.h
+++ b/include/treewidth/LowerBound.h
@@ -23,7 +23,9 @@ protected:
 public:
   LowerBound(Graph& graph, PermutationStrategy& strategy) :\
   graph(graph), strategy(strategy) {};
-  
+
+  virtual ~LowerBound() = default;
+
   void setGraph(Graph& newGraph) { graph = newGraph;}
   
   void setStrategy(PermutationStrategy& newStrategy) {strategy = newStrategy;}

--- a/include/treewidth/LowerBound.h
+++ b/include/treewidth/LowerBound.h
@@ -61,7 +61,7 @@ public:
     while(!strategy.empty()){
       unsigned long node = strategy.get_next();
       u = u+1;
-      std::unordered_set<unsigned long> neigh = graph.get_neighbours(node);
+      boost::unordered_flat_set<unsigned long> neigh = graph.get_neighbours(node);
       treewidth = std::max(treewidth,neigh.size());
       //getting the neighbour with least overlap
       unsigned long min_v = 0;

--- a/include/treewidth/LowerBound.h
+++ b/include/treewidth/LowerBound.h
@@ -68,7 +68,7 @@ public:
       for(auto v:neigh){
         unsigned long ovl = 0;
         for(auto nv:graph.get_neighbours(v))
-          if(graph.has_edge(node,nv)) ovl++;
+          if(neigh.find(nv)!=neigh.end()) ovl++;
         if(min_ovl>=ovl){
           min_v = v;
           min_ovl = ovl;

--- a/include/treewidth/LowerBound.h
+++ b/include/treewidth/LowerBound.h
@@ -18,19 +18,24 @@
 
 class LowerBound {
 protected:
-  Graph& graph;
+  //`graph` is a rebindable pointer, not a reference: setGraph() must repoint the
+  //bound at a different Graph. A meta-heuristic (LBN/LBN+) hands the base bound a
+  //throwaway copy to estimate on; a destructive base (MMD/MMD+) must destroy that
+  //copy, not the meta's shared graph. With a reference member, `graph = newGraph`
+  //copy-assigned into the shared graph and emptied it, making LBN/LBN+ no-ops.
+  Graph* graph;
   PermutationStrategy& strategy;
 public:
   LowerBound(Graph& graph, PermutationStrategy& strategy) :\
-  graph(graph), strategy(strategy) {};
+  graph(&graph), strategy(strategy) {};
 
   virtual ~LowerBound() = default;
 
-  void setGraph(Graph& newGraph) { graph = newGraph;}
-  
+  void setGraph(Graph& newGraph) { graph = &newGraph;}
+
   void setStrategy(PermutationStrategy& newStrategy) {strategy = newStrategy;}
-  
-  Graph& getGraph() {return graph;}
+
+  Graph& getGraph() {return *graph;}
   
   PermutationStrategy& getStrategy() {return strategy;}
   
@@ -51,7 +56,7 @@ public:
     //building the first permutation
     //std::cout << "graph: " << graph.number_nodes() << " nodes " <<
     //graph.number_edges() << " edges" << std::endl;
-    strategy.init_permutation(graph);
+    strategy.init_permutation(*graph);
     treewidth = 0;
     unsigned long num_node = 0;
     //looping greedily through the permutation
@@ -61,7 +66,7 @@ public:
     while(!strategy.empty()){
       unsigned long node = strategy.get_next();
       u = u+1;
-      boost::unordered_flat_set<unsigned long> neigh = graph.get_neighbours(node);
+      boost::unordered_flat_set<unsigned long> neigh = graph->get_neighbours(node);
       treewidth = std::max(treewidth,neigh.size());
       //getting the neighbour with least overlap
       unsigned long min_v = 0;
@@ -69,18 +74,18 @@ public:
       //std::cout<<"2 point\n";
       for(auto v:neigh){
         unsigned long ovl = 0;
-        for(auto nv:graph.get_neighbours(v))
+        for(auto nv:graph->get_neighbours(v))
           if(neigh.find(nv)!=neigh.end()) ovl++;
         if(min_ovl>=ovl){
           min_v = v;
           min_ovl = ovl;
         }
       }
-      
+
       //contracting the edge
-      graph.contract_edge(min_v,node);
+      graph->contract_edge(min_v,node);
       //recomputing the degrees in the graph
-      strategy.recompute(neigh, graph);
+      strategy.recompute(neigh, *graph);
       num_node++;
       //std::cout<<u<<"\n";
     }

--- a/include/treewidth/LowerBoundMMD.h
+++ b/include/treewidth/LowerBoundMMD.h
@@ -32,7 +32,7 @@ public:
   		//graph.number_edges() << " edges" << std::endl;
   
 		//building the first permutation
-		strategy.init_permutation(graph);
+		strategy.init_permutation(*graph);
 		treewidth = 0;
 		unsigned long num_node = 0;
 		//looping greedily through the permutation
@@ -41,12 +41,12 @@ public:
 			//getting the next node
 			unsigned long node = strategy.get_next();
 			u = u+1;
-			boost::unordered_flat_set<unsigned long> neigh = graph.get_neighbours(node);
+			boost::unordered_flat_set<unsigned long> neigh = graph->get_neighbours(node);
 			treewidth = std::max(treewidth, neigh.size());
 		//Remove the Node
-		graph.remove_node(node);
+		graph->remove_node(node);
 		//recomputing the degrees in the graph
-		strategy.recompute(neigh, graph);
+		strategy.recompute(neigh, *graph);
 		num_node++;
 	}
 	return treewidth;

--- a/include/treewidth/LowerBoundMMD.h
+++ b/include/treewidth/LowerBoundMMD.h
@@ -41,7 +41,7 @@ public:
 			//getting the next node
 			unsigned long node = strategy.get_next();
 			u = u+1;
-			std::unordered_set<unsigned long> neigh = graph.get_neighbours(node);
+			boost::unordered_flat_set<unsigned long> neigh = graph.get_neighbours(node);
 			treewidth = std::max(treewidth, neigh.size());
 		//Remove the Node
 		graph.remove_node(node);

--- a/include/treewidth/MCSPermutationStrategy.h
+++ b/include/treewidth/MCSPermutationStrategy.h
@@ -10,7 +10,7 @@
 //    is chosen
 class MCSPermutationStrategy: public PermutationStrategy{
 public:
-  void recompute(std::unordered_set<unsigned long>, Graph& graph){
+  void recompute(const std::unordered_set<unsigned long>&, Graph& graph) override{
     for(auto node:graph.get_nodes()){
       node_type nstruct;
       nstruct.id = node;

--- a/include/treewidth/MCSPermutationStrategy.h
+++ b/include/treewidth/MCSPermutationStrategy.h
@@ -10,7 +10,7 @@
 //    is chosen
 class MCSPermutationStrategy: public PermutationStrategy{
 public:
-  void recompute(const std::unordered_set<unsigned long>&, Graph& graph) override{
+  void recompute(const boost::unordered_flat_set<unsigned long>&, Graph& graph) override{
     for(auto node:graph.get_nodes()){
       node_type nstruct;
       nstruct.id = node;

--- a/include/treewidth/MetaLowerBoundHeuristic.h
+++ b/include/treewidth/MetaLowerBoundHeuristic.h
@@ -19,7 +19,9 @@ protected:
 public:
   MetaLowerBoundHeuristic(Graph& graph, LowerBound& lower_bound) :\
   graph(graph), lower_bound(lower_bound) {};
-  
+
+  virtual ~MetaLowerBoundHeuristic() = default;
+
   virtual unsigned long estimate()=0;
 };
 

--- a/include/treewidth/PermutationStrategy.h
+++ b/include/treewidth/PermutationStrategy.h
@@ -20,18 +20,22 @@ protected:
     boost::heap::fibonacci_heap<node_type>::handle_type> queue_nodes;
 
 public:
-  //Clears any residual queue state. Must be called before reusing the same
-  //strategy instance on a fresh/different graph if the previous
-  //init_permutation() was not fully drained (e.g. Delta2D, which stops at
-  //one remaining node per call) -- otherwise stale entries from the previous
-  //call linger in the queue and desync it from the graph being processed.
+  //Clears any residual queue state. init_permutation() calls this itself, but
+  //it is also exposed for callers that need to reset the queue explicitly.
   void clear(){
     queue.clear();
     queue_nodes.clear();
   }
 
-  //Computes the initial permutation for all nodes in the graph
+  //Computes the initial permutation for all nodes in the graph.
+  //Clears first: the same strategy instance is reused on fresh/different graphs
+  //(e.g. Delta2D per node, and the shared strategy driving both CE::con_edge and
+  //a base LowerBound inside LBN/LBN+). A previous call that was not fully drained
+  //would otherwise leave stale entries that desync the queue from this graph --
+  //get_next() would return a node absent from it (get_neighbours assertion /
+  //empty-set fallback).
   void init_permutation(Graph& graph){
+    clear();
     for(auto node:graph.get_nodes()){
       node_type nstruct;
       nstruct.id = node;

--- a/include/treewidth/PermutationStrategy.h
+++ b/include/treewidth/PermutationStrategy.h
@@ -20,6 +20,16 @@ protected:
     boost::heap::fibonacci_heap<node_type>::handle_type> queue_nodes;
 
 public:
+  //Clears any residual queue state. Must be called before reusing the same
+  //strategy instance on a fresh/different graph if the previous
+  //init_permutation() was not fully drained (e.g. Delta2D, which stops at
+  //one remaining node per call) -- otherwise stale entries from the previous
+  //call linger in the queue and desync it from the graph being processed.
+  void clear(){
+    queue.clear();
+    queue_nodes.clear();
+  }
+
   //Computes the initial permutation for all nodes in the graph
   void init_permutation(Graph& graph){
     for(auto node:graph.get_nodes()){

--- a/include/treewidth/PermutationStrategy.h
+++ b/include/treewidth/PermutationStrategy.h
@@ -16,7 +16,7 @@ protected:
     }
   };
   boost::heap::fibonacci_heap<node_type> queue;
-  std::unordered_map<unsigned long,
+  boost::unordered_flat_map<unsigned long,
     boost::heap::fibonacci_heap<node_type>::handle_type> queue_nodes;
 
 public:
@@ -49,7 +49,7 @@ public:
   }
   
   //Recomputes the statistic and updates the queue for a subset of nodes
-  virtual void recompute(const std::unordered_set<unsigned long> &nodes, Graph& graph){
+  virtual void recompute(const boost::unordered_flat_set<unsigned long> &nodes, Graph& graph){
     for(auto node:nodes){
       node_type nstruct;
       nstruct.id = node;

--- a/include/treewidth/TreeDecomposition.h
+++ b/include/treewidth/TreeDecomposition.h
@@ -67,8 +67,7 @@ public:
       strategy.recompute(neigh, graph);
       //adding the bag
       neigh.insert(node);
-      Bag bag = Bag(bag_id, neigh);
-      bags.push_back(bag);
+      bags.emplace_back(bag_id, neigh);
       bag_ids[node] = bag_id;
       bag_id++;
       if(bag_id%one==0){
@@ -121,7 +120,7 @@ public:
 inline std::ostream& operator<<(std::ostream& out, TreeDecomposition& dec){
   out << dec.treewidth << "\n";
   out << dec.bags.size() << "\n";
-  for(Bag bag:dec.bags) out << bag;
+  for(Bag& bag:dec.bags) out << bag;
   return out;
 }
 

--- a/include/treewidth/TreeDecomposition.h
+++ b/include/treewidth/TreeDecomposition.h
@@ -18,7 +18,7 @@ private:
   Graph& graph;
   PermutationStrategy& strategy;
   std::vector<Bag> bags;
-  std::unordered_map<unsigned long, unsigned long> bag_ids;
+  boost::unordered_flat_map<unsigned long, unsigned long> bag_ids;
   unsigned long treewidth = 0;
   std::stringstream stat;
 public:
@@ -48,7 +48,7 @@ public:
       //getting the next node
       unsigned long node = strategy.get_next();
       //removing the node from the graph and getting its neighbours
-      std::unordered_set<unsigned long> neigh = graph.remove_node(node);
+      boost::unordered_flat_set<unsigned long> neigh = graph.remove_node(node);
       unsigned long width = neigh.size();
       unsigned long prev_max_bag = max_bag;
       unsigned long new_max_bag = std::max(width,max_bag);

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -51,3 +51,23 @@ TEST_CASE("contract_edge merges the target into the source") {
   REQUIRE_FALSE(g.has_node(1));
   REQUIRE(g.has_edge(0, 2));
 }
+
+TEST_CASE("get_neighbours on a present-but-isolated node returns empty, not UB") {
+  // add_node() puts the node in node_set without ever creating an adj_list
+  // entry for it, so it is present (has_node) but has no adjacency entry
+  // (has_neighbours is false). Before the fix, get_neighbours dereferenced
+  // adj_list.find(node)->second unconditionally, which is end() here (UB).
+  Graph g;
+  g.add_node(42);
+  REQUIRE(g.has_node(42));
+  REQUIRE_FALSE(g.has_neighbours(42));
+  const auto& neigh = g.get_neighbours(42);
+  REQUIRE(neigh.empty());
+
+  // Also exercise it alongside a normal edge, to make sure the shared empty
+  // set doesn't get confused with a real node's adjacency.
+  g.add_edge(1, 2);
+  g.add_node(99);
+  REQUIRE(g.get_neighbours(99).empty());
+  REQUIRE(g.get_neighbours(1).count(2) == 1);
+}

--- a/tests/test_graph.cpp
+++ b/tests/test_graph.cpp
@@ -1,4 +1,4 @@
-#include <unordered_set>
+#include <boost/unordered/unordered_flat_set.hpp>
 
 #include "catch.hpp"
 #include "Graph.h"
@@ -38,7 +38,7 @@ TEST_CASE("fill turns a neighbourhood into a clique") {
   g.add_edge(0, 1);
   g.add_edge(0, 2);
   g.add_edge(0, 3);
-  std::unordered_set<unsigned long> ns{1, 2, 3};
+  boost::unordered_flat_set<unsigned long> ns{1, 2, 3};
   g.fill(ns);
   REQUIRE(g.has_edge(1, 2));
   REQUIRE(g.has_edge(1, 3));

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -6,14 +6,22 @@
 #include "DegreePermutationStrategy.h"
 #include "LowerBound.h"
 #include "LowerBoundMMD.h"
+#include "Delta2D.h"
+#include "LBN.h"
+#include "LBNPlus.h"
 #include "TreeDecomposition.h"
 #include "graph_builders.h"
 
-// Delta2D and the meta-heuristics (LBN / LBN+) are intentionally excluded here:
-// Delta2D queries get_neighbours() for an already-removed node (assertion in a
-// debug build, SIGSEGV under NDEBUG), and LBN/LBN+ drive the known-buggy CE
-// contraction and the isolated-node get_neighbours UB. These paths are covered
-// once those bugs are fixed.
+// Delta2D and the meta-heuristics (LBN / LBN+) used to be excluded here:
+// Delta2D queried get_neighbours() for an already-removed node (assertion in
+// a debug build, SIGSEGV under NDEBUG, because the strategy queue and
+// graph_temp had desynced across estimateForNode() calls), and LBN/LBN+ drove
+// the buggy CE contraction (contracted on every neighbour-selection loop
+// iteration instead of once after it) and the isolated-node get_neighbours UB.
+// All four fixes are now in place (PermutationStrategy::clear(), the
+// get_neighbours empty-set fallback, the genuine MCS recompute() override,
+// and CE::con_edge() contracting once after its loop), so these paths are
+// exercised below.
 
 static unsigned long upper_tw(Graph g) {
   DegreePermutationStrategy s;
@@ -48,4 +56,93 @@ TEST_CASE("MMD lower bound equals n-1 for a clique") {
   DegreePermutationStrategy s;
   LowerBoundMMD lb(g, s);
   REQUIRE(lb.estimate() == 4);
+}
+
+// --- Delta2D (bug 2: strategy-queue / graph_temp desync, SIGSEGV under
+// NDEBUG) -------------------------------------------------------------
+
+TEST_CASE("Delta2D lower bound is between 1 and the greedy upper bound") {
+  std::vector<Graph> graphs{clique(5), cycle(6), grid(3, 3),
+                            sample_two_triangles()};
+  for (auto& base : graphs) {
+    unsigned long up = upper_tw(base);
+    Graph g = base;
+    DegreePermutationStrategy s;
+    Delta2D lb(g, s);
+    unsigned long lo = lb.estimate();
+    REQUIRE(lo >= 1);
+    REQUIRE(lo <= up);
+  }
+}
+
+TEST_CASE("Delta2D lower bound equals the greedy upper bound on a clique") {
+  // A discriminating case: on clique(5) Delta2D's bound is tight (4), equal
+  // to the greedy min-degree upper bound, rather than a loose lower value.
+  Graph g = clique(5);
+  DegreePermutationStrategy s;
+  Delta2D lb(g, s);
+  REQUIRE(lb.estimate() == 4);
+}
+
+// --- LBN / LBN+ meta lower bounds (bug 1: isolated-node get_neighbours UB
+// reachable via neighbour_improved(); bug 4: CE double-contraction) --------
+//
+// LBN/LBN+ hold their own Graph& alongside the wrapped LowerBound's Graph&,
+// and both are bound to the very same Graph object here -- mirroring how
+// src/main.cpp wires `new LBN(graph, *bounds[lb])` with `bounds[lb]` already
+// constructed on that identical `graph`. LowerBound::setGraph() assigns into
+// the referenced object rather than rebinding the reference, so a *destructive*
+// base bound (LowerBoundMMD/LowerBoundMMDPlus, which remove/contract nodes out
+// of its own graph reference as it runs) empties the shared graph before the
+// meta-heuristic's neighbour-improvement loop -- and LBN+'s CE contraction --
+// ever get a chance to run on real edges. Delta2D does not mutate its own
+// graph reference (it works on an internal copy), so using it as the base
+// bound is what actually drives the improvement loop and the fixed CE path.
+
+TEST_CASE("LBN meta lower bound (Delta2D base) is between 1 and the upper bound") {
+  std::vector<Graph> graphs{clique(5), cycle(6), grid(3, 3),
+                            sample_two_triangles()};
+  for (auto& base : graphs) {
+    unsigned long up = upper_tw(base);
+    Graph g = base;
+    DegreePermutationStrategy s;
+    Delta2D base_lb(g, s);
+    LBN lbn(g, base_lb);
+    unsigned long lo = lbn.estimate();
+    REQUIRE(lo >= 1);
+    REQUIRE(lo <= up);
+  }
+}
+
+TEST_CASE("LBN+ meta lower bound (Delta2D base) is between 1 and the upper bound") {
+  std::vector<Graph> graphs{clique(5), cycle(6), grid(3, 3),
+                            sample_two_triangles()};
+  for (auto& base : graphs) {
+    unsigned long up = upper_tw(base);
+    Graph g = base;
+    DegreePermutationStrategy s;
+    Delta2D base_lb(g, s);
+    LBNPlus lbnp(g, base_lb);
+    unsigned long lo = lbnp.estimate();
+    REQUIRE(lo >= 1);
+    REQUIRE(lo <= up);
+  }
+}
+
+TEST_CASE("LBN meta lower bound (MMD base) is between 1 and the upper bound") {
+  // MMD is destructive to the shared graph reference (see note above), so
+  // this exercises LBN's degenerate-but-safe path: no crash, and the
+  // invariant still holds even though the improvement loop can't add edges.
+  std::vector<Graph> graphs{clique(5), cycle(6), grid(3, 3),
+                            sample_two_triangles()};
+  for (auto& base : graphs) {
+    unsigned long up = upper_tw(base);
+    Graph g = base;
+    DegreePermutationStrategy s;
+    LowerBoundMMD base_lb(g, s);
+    LBN lbn(g, base_lb);
+    unsigned long lo = lbn.estimate();
+    REQUIRE(lo >= 1);
+    REQUIRE(lo <= up);
+  }
 }

--- a/tests/test_lower.cpp
+++ b/tests/test_lower.cpp
@@ -84,20 +84,17 @@ TEST_CASE("Delta2D lower bound equals the greedy upper bound on a clique") {
   REQUIRE(lb.estimate() == 4);
 }
 
-// --- LBN / LBN+ meta lower bounds (bug 1: isolated-node get_neighbours UB
-// reachable via neighbour_improved(); bug 4: CE double-contraction) --------
+// --- LBN / LBN+ meta lower bounds ---------------------------------------
 //
-// LBN/LBN+ hold their own Graph& alongside the wrapped LowerBound's Graph&,
-// and both are bound to the very same Graph object here -- mirroring how
-// src/main.cpp wires `new LBN(graph, *bounds[lb])` with `bounds[lb]` already
-// constructed on that identical `graph`. LowerBound::setGraph() assigns into
-// the referenced object rather than rebinding the reference, so a *destructive*
-// base bound (LowerBoundMMD/LowerBoundMMDPlus, which remove/contract nodes out
-// of its own graph reference as it runs) empties the shared graph before the
-// meta-heuristic's neighbour-improvement loop -- and LBN+'s CE contraction --
-// ever get a chance to run on real edges. Delta2D does not mutate its own
-// graph reference (it works on an internal copy), so using it as the base
-// bound is what actually drives the improvement loop and the fixed CE path.
+// LBN/LBN+ hold their own Graph& alongside the wrapped LowerBound, both bound
+// to the same Graph object here -- mirroring src/main.cpp's
+// `new LBN(graph, *bounds[lb])`. LowerBound::graph is now a rebindable pointer,
+// so setGraph() repoints the base bound at the throwaway copy a meta-heuristic
+// hands it; a destructive base (LowerBoundMMD/LowerBoundMMDPlus) destroys that
+// copy rather than the meta's shared graph, and the neighbour-improvement loop
+// (and LBN+'s CE contraction) run on real edges. Previously setGraph()
+// copy-assigned into the shared graph, emptying it and making the MMD/MMD+
+// based meta bounds silent no-ops (fixed; see the improvement test below).
 
 TEST_CASE("LBN meta lower bound (Delta2D base) is between 1 and the upper bound") {
   std::vector<Graph> graphs{clique(5), cycle(6), grid(3, 3),
@@ -130,9 +127,8 @@ TEST_CASE("LBN+ meta lower bound (Delta2D base) is between 1 and the upper bound
 }
 
 TEST_CASE("LBN meta lower bound (MMD base) is between 1 and the upper bound") {
-  // MMD is destructive to the shared graph reference (see note above), so
-  // this exercises LBN's degenerate-but-safe path: no crash, and the
-  // invariant still holds even though the improvement loop can't add edges.
+  // With the setGraph() fix the destructive MMD base no longer empties the
+  // meta's shared graph, so this drives LBN's improvement loop on real edges.
   std::vector<Graph> graphs{clique(5), cycle(6), grid(3, 3),
                             sample_two_triangles()};
   for (auto& base : graphs) {
@@ -142,6 +138,50 @@ TEST_CASE("LBN meta lower bound (MMD base) is between 1 and the upper bound") {
     LowerBoundMMD base_lb(g, s);
     LBN lbn(g, base_lb);
     unsigned long lo = lbn.estimate();
+    REQUIRE(lo >= 1);
+    REQUIRE(lo <= up);
+  }
+}
+
+// Regression anchor for the setGraph() no-op fix: with a *destructive* MMD
+// base, LBN+ must be able to strictly improve on the base bound rather than
+// silently returning it. On the 4x4 grid (treewidth 4) the plain MMD bound is
+// 2; the fixed LBN+ neighbour-improvement + contraction reaches the exact
+// treewidth 4. Before the fix this returned the base value (2), unchanged.
+TEST_CASE("LBN+ meta lower bound (MMD base) improves over the base bound") {
+  Graph grid44 = grid(4, 4);
+  unsigned long up = upper_tw(grid44);
+
+  unsigned long base_val;
+  {
+    Graph g = grid44;
+    DegreePermutationStrategy s;
+    LowerBoundMMD base_lb(g, s);
+    base_val = base_lb.estimate();
+  }
+
+  Graph g = grid44;
+  DegreePermutationStrategy s;
+  LowerBoundMMD base_lb(g, s);
+  LBNPlus lbnp(g, base_lb);
+  unsigned long meta_val = lbnp.estimate();
+
+  REQUIRE(meta_val > base_val);   // fix active: not a silent no-op
+  REQUIRE(meta_val <= up);        // still a valid lower bound
+}
+
+// LBN+ with the destructive MMD+ base must also stay valid (<= upper) on the
+// standard graphs now that it runs on real edges.
+TEST_CASE("LBN+ meta lower bound (MMD+ base) is between 1 and the upper bound") {
+  std::vector<Graph> graphs{clique(5), cycle(6), grid(3, 3), grid(4, 4),
+                            sample_two_triangles()};
+  for (auto& base : graphs) {
+    unsigned long up = upper_tw(base);
+    Graph g = base;
+    DegreePermutationStrategy s;
+    LowerBoundMMDPlus base_lb(g, s);
+    LBNPlus lbnp(g, base_lb);
+    unsigned long lo = lbnp.estimate();
     REQUIRE(lo >= 1);
     REQUIRE(lo <= up);
   }

--- a/tests/test_serialization.cpp
+++ b/tests/test_serialization.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <sstream>
-#include <unordered_set>
+#include <boost/unordered/unordered_flat_set.hpp>
 
 #include "catch.hpp"
 #include "Bag.h"
@@ -10,7 +10,7 @@
 #include "graph_builders.h"
 
 TEST_CASE("Bag serializes id, node list, parent and child count") {
-  std::unordered_set<unsigned long> ns{7};
+  boost::unordered_flat_set<unsigned long> ns{7};
   Bag bag(3, ns);
   std::ostringstream ss;
   ss << bag;

--- a/tests/test_upper.cpp
+++ b/tests/test_upper.cpp
@@ -34,8 +34,13 @@ TEST_CASE("upper bound never exceeds N-1 (N = number of nodes)") {
 }
 
 // Golden treewidth values (first line of the .dec output) pinned per method on
-// the CLI baseline graph. Method 3 (MCS) pins current known-buggy behavior on
-// purpose, as a regression anchor.
+// the CLI baseline graph. Method 3 (MCS) used to run through a by-value
+// recompute() override that silently fell back to the base-class statistic
+// (a no-op override bug); MCSPermutationStrategy::recompute now genuinely
+// overrides the base and the MCS-specific logic is live. The pinned width of
+// 3 was verified unchanged across the fix (ties break the same way), so this
+// remains the correct golden value -- it is no longer pinning known-buggy
+// behavior, it is pinning the fixed, intended behavior.
 TEST_CASE("golden treewidth per method on the sample graph") {
   { DegreePermutationStrategy s;       REQUIRE(upper_tw(sample_two_triangles(), s) == 2); }
   { FillInPermutationStrategy s;       REQUIRE(upper_tw(sample_two_triangles(), s) == 2); }


### PR DESCRIPTION
## Performance

- **Fill-in strategies** (`min-fill-in`, `degree+fill-in`): eliminate
  per-neighbour `unordered_set` copies and short-circuit `neighbour_improved`.
- **Degree strategy** : switch graph/queue containers from `std::unordered_*` to
  `boost::unordered_flat_*`. 

## Correctness fixes

1. **`Graph::get_neighbours` isolated-node UB** — returned a dereferenced
   `end()` for a present-but-isolated node; now returns a shared empty set.
2. **`Delta2D` strategy/graph desync** — read a removed node's neighbours
   (assertion in debug, **SIGSEGV under `NDEBUG`**); fixed by clearing the
   reused strategy queue before re-init.
3. **`MCSPermutationStrategy::recompute` didn't override** the base (took
   its set by value → MCS was dead code); signature matched + `override`,
   with `-Woverloaded-virtual` added to catch the class of bug.
4. **`CE::con_edge` contracted inside its selection loop** instead of once
   after it (reached via LBN+).
5. **Missing virtual destructors** on `LowerBound` / `MetaLowerBoundHeuristic`
   — deleted through base `unique_ptr`s in `main.cpp` (UB;
   `new-delete-type-mismatch` under ASan).

